### PR TITLE
Remove unnecessary `config:` root from configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Changed
 
-- Something
-
+- Remove the root `.config` from the configuration
 
 ## [1.0.0] - YYYY-MM-DD
 ### Added

--- a/src/main/conf/ds-kaltura-behaviour.yaml
+++ b/src/main/conf/ds-kaltura-behaviour.yaml
@@ -9,16 +9,15 @@
 # application config system.
 #
 #
-config:
-  # Only for integration test
-  kaltura:
-    url:  'https://kmc.kaltura.nordu.net'
-    partnerId:  380
-    userId:  'XXX@kb.dk'
-    adminSecret: 'xxxxx'
-    sessionKeepAliveSeconds: 86400
-    
-  # The configuration can auto-update at set intervals. See ServiceConfig for details
-  autoupdate:
-    enabled: false
-    intervalms: 60000
+# Only for integration test
+kaltura:
+  url:  'https://kmc.kaltura.nordu.net'
+  partnerId:  380
+  userId:  'XXX@kb.dk'
+  adminSecret: 'xxxxx'
+  sessionKeepAliveSeconds: 86400
+
+# The configuration can auto-update at set intervals. See ServiceConfig for details
+autoupdate:
+  enabled: false
+  intervalms: 60000

--- a/src/main/java/dk/kb/kaltura/config/ServiceConfig.java
+++ b/src/main/java/dk/kb/kaltura/config/ServiceConfig.java
@@ -16,10 +16,9 @@ import java.util.Set;
  * If wanted, changes to the configuration source (typically files) can result in an update of the ServiceConfig and
  * a callback to relevant classes. To enable this, add autoupdate keys to the YAML config:
  * <pre>
- * config:
- *   autoupdate:
- *     enabled: true
- *     intervalms: 60000
+ * autoupdate:
+ *   enabled: true
+ *   intervalms: 60000
  * </pre>
  * Notifications on config changes can be received using {@link #registerObserver(Observer)}.
  *
@@ -37,9 +36,9 @@ public class ServiceConfig {
 
     private static final Set<Observer> observers = new HashSet<>();
 
-    private static final String AUTO_UPDATE_KEY = ".config.autoupdate.enabled";
+    private static final String AUTO_UPDATE_KEY = ".autoupdate.enabled";
     private static final boolean AUTO_UPDATE_DEFAULT = false;
-    private static final String AUTO_UPDATE_MS_KEY = ".config.autoupdate.intervalms";
+    private static final String AUTO_UPDATE_MS_KEY = ".autoupdate.intervalms";
     private static final long AUTO_UPDATE_MS_DEFAULT = 60*1000; // every minute
 
     private static boolean autoUpdate = AUTO_UPDATE_DEFAULT;
@@ -114,7 +113,7 @@ public class ServiceConfig {
 
     
     public static String getKalturaUrl() {
-        return serviceConfig.getString("config.kaltura.url");
+        return serviceConfig.getString("kaltura.url");
     }
 
 

--- a/src/main/java/dk/kb/kaltura/jobs/JobsBase.java
+++ b/src/main/java/dk/kb/kaltura/jobs/JobsBase.java
@@ -14,11 +14,11 @@ public abstract class JobsBase {
     public static DsKalturaClient getKalturaClient() throws IOException {
 
         ServiceConfig.initialize(System.getProperty("dk.kb.applicationConfig"));        
-        String kalturaUrl=ServiceConfig.getConfig().getString("config.kaltura.url");
-        String userId=ServiceConfig.getConfig().getString("config.kaltura.userId");
-        int partnerId=ServiceConfig.getConfig().getInteger("config.kaltura.partnerId");        
-        String adminSecret=ServiceConfig.getConfig().getString("config.kaltura.adminSecret");
-        long keepAliveSeconds=ServiceConfig.getConfig().getLong("config.kaltura.sessionKeepAliveSeconds");
+        String kalturaUrl=ServiceConfig.getConfig().getString("kaltura.url");
+        String userId=ServiceConfig.getConfig().getString("kaltura.userId");
+        int partnerId=ServiceConfig.getConfig().getInteger("kaltura.partnerId");        
+        String adminSecret=ServiceConfig.getConfig().getString("kaltura.adminSecret");
+        long keepAliveSeconds=ServiceConfig.getConfig().getLong("kaltura.sessionKeepAliveSeconds");
 
         DsKalturaClient client = new DsKalturaClient(kalturaUrl, userId, partnerId, adminSecret, keepAliveSeconds);               
         return client;        


### PR DESCRIPTION
Part of the config style alignment