### PR TITLE
Map multiple IDs

### DIFF
--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.kaltura.client.enums.ESearchItemType;
+import com.kaltura.client.services.ESearchService;
+import com.kaltura.client.types.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,12 +23,6 @@ import com.kaltura.client.services.MediaService.ListMediaBuilder;
 import com.kaltura.client.services.UploadTokenService;
 import com.kaltura.client.services.UploadTokenService.AddUploadTokenBuilder;
 import com.kaltura.client.services.UploadTokenService.UploadUploadTokenBuilder;
-import com.kaltura.client.types.FilterPager;
-import com.kaltura.client.types.ListResponse;
-import com.kaltura.client.types.MediaEntryFilter;
-import com.kaltura.client.types.UploadToken;
-import com.kaltura.client.types.UploadedFileTokenResource;
-import com.kaltura.client.types.MediaEntry;
 import com.kaltura.client.Client;
 import com.kaltura.client.utils.response.base.Response;
 
@@ -120,6 +117,25 @@ public class DsKalturaClient {
         }
 
         return response.results.getObjects().get(0).getId();    
+    }
+
+    public String getKulturaInternalIds(List<String> referenceIds) throws IOException{
+
+        // Adapted from Java samples at https://developer.kaltura.com
+
+        // https://developer.kaltura.com/console/service/eSearch/action/searchEntry?query=search
+        Client clientSession = getClientInstance();
+        ESearchEntryParams searchParams = new ESearchEntryParams();
+        ESearchEntryOperator operator = new ESearchEntryOperator();
+        searchParams.setSearchOperator(operator);
+
+        ESearchUnifiedItem item = new ESearchUnifiedItem();
+        item.setItemType(ESearchItemType.EXACT_MATCH);
+        item.searchTerm(referenceIds.get(0));
+        operator.setSearchItems(List.of(item));
+
+        ESearchService.SearchEntryESearchBuilder requestBuilder = ESearchService.searchEntry(searchParams);
+        return requestBuilder.build(clientSession).getBody();
     }
 
     /**
@@ -223,7 +239,3 @@ public class DsKalturaClient {
         }
     }
 }
-
-
-
-

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -5,6 +5,7 @@ import com.kaltura.client.Client;
 import com.kaltura.client.Configuration;
 import com.kaltura.client.enums.ESearchEntryFieldName;
 import com.kaltura.client.enums.ESearchItemType;
+import com.kaltura.client.enums.ESearchOperatorType;
 import com.kaltura.client.enums.MediaType;
 import com.kaltura.client.enums.SessionType;
 import com.kaltura.client.services.ESearchService;
@@ -223,6 +224,7 @@ public class DsKalturaClient {
         // Setup request
         ESearchEntryParams searchParams = new ESearchEntryParams();
         ESearchEntryOperator operator = new ESearchEntryOperator();
+        operator.setOperator(ESearchOperatorType.OR_OP);
         searchParams.setSearchOperator(operator);
         operator.setSearchItems(items);
         FilterPager pager = new FilterPager();

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -202,7 +202,7 @@ public class DsKalturaClient {
     private synchronized Client getClientInstance() throws IOException{
         try {
 
-            if (System.currentTimeMillis()-lastSessionStart >= sessionKeepAliveSeconds/1000) {            
+            if (System.currentTimeMillis()-lastSessionStart >= sessionKeepAliveSeconds*1000) {
                 //Create the client
                 //KalturaConfiguration config = new KalturaConfiguration();
                 Configuration config = new Configuration();

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import dk.kb.kaltura.config.ServiceConfig;
 import dk.kb.util.yaml.YAML;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -39,15 +40,22 @@ public class KalturaApiIntegrationTest {
     public static final String REFERENCE_ID1 = "9ac77346-32d5-4733-b38f-91dd25649f88";
     public static final String REFERENCE_ID2 = "108c27ed-4e7a-4d4b-8674-9fee57ab925f";
     public static final String REFERENCE_ID3 = "89fbdd2e-82b1-483a-99d7-810101ef33b2";
+
     // referenceID, kalturaID
-    public static final List<List<String>> KNOWN_PAIRS_NEW = List.of(
+    public static final List<List<String>> KNOWN_PAIRS_1 = List.of(
+            List.of(REFERENCE_ID1, KALTURA_ID1)
+    );
+    public static final List<List<String>> KNOWN_PAIRS_3 = List.of(
             List.of(REFERENCE_ID1, KALTURA_ID1),
             List.of(REFERENCE_ID2, KALTURA_ID2),
             List.of(REFERENCE_ID3, KALTURA_ID3)
     );
-    public static final List<List<String>> KNOWN_PAIRS = List.of(
+    public static final List<List<String>> KNOWN_PAIRS_OLD = List.of(
             List.of("7f7ffcbc-58dc-40bd-8ca9-12d0f9cf3ed7", "0_vvp1ozjl")
     );
+
+    // The IDs used by the unit test
+    public static final List<List<String>> KNOWN_PAIRS = KNOWN_PAIRS_3;
 
     @BeforeAll
     public static void setup() throws IOException {
@@ -94,7 +102,8 @@ public class KalturaApiIntegrationTest {
         System.out.println(ids);
     }
 
-    @Test
+    // Old stress test to see why repeated calls failed (they don't anymore)
+    @Disabled
     public void callKalturaApi() throws Exception{
 
         //These data can change in Kaltura

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
+import java.util.List;
 
 import dk.kb.kaltura.config.ServiceConfig;
 import dk.kb.util.yaml.YAML;
@@ -36,6 +37,16 @@ public class KalturaApiIntegrationTest {
             throw new IllegalStateException("The kaltura.adminSecret must be set to perform integration test. " +
                     "Please add it to the local configuration (NOT the *-behaviour.YAML configuration)");
         }
+    }
+
+    @Test
+    public void multipleLookups() throws IOException {
+        //These data can change in Kaltura
+        String referenceId="7f7ffcbc-58dc-40bd-8ca9-12d0f9cf3ed7";
+        String kalturaInternallId="0_vvp1ozjl";
+
+        DsKalturaClient clientSession = getClientSession();
+        System.out.println(clientSession.getKulturaInternalIds(List.of("dr")).replace("{", "\n{"));
     }
 
     @Test

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -51,7 +51,7 @@ public class KalturaApiIntegrationTest {
                 List.of(referenceId,kalturaInternallId)
         );
 
-        DsKalturaClient clientSession = getClientSession();
+        DsKalturaClient clientSession = getClient();
         Map<String, String> map = clientSession.getKulturaInternalIds(
                 tests.stream().map(e -> e.get(0)).collect(Collectors.toList()));
 
@@ -64,13 +64,20 @@ public class KalturaApiIntegrationTest {
     }
 
     @Test
+    public void simpleSearch() throws IOException {
+        List<String> ids = getClient().searchTerm("dr");
+        assertFalse(ids.isEmpty(), "Search result should not be empty");
+        System.out.println(ids);
+    }
+
+    @Test
     public void callKalturaApi() throws Exception{
                                
         //These data can change in Kaltura
         String referenceId="7f7ffcbc-58dc-40bd-8ca9-12d0f9cf3ed7"; 
         String kalturaInternallId="0_vvp1ozjl";
 
-        DsKalturaClient clientSession=getClientSession();
+        DsKalturaClient clientSession= getClient();
         
         int success=0;
         for (int i = 0;i<10;i++) {                  
@@ -89,7 +96,7 @@ public class KalturaApiIntegrationTest {
      */
     @Test
     public void kalturaUpload() throws Exception{                             
-            DsKalturaClient clientSession=getClientSession();                  
+            DsKalturaClient clientSession= getClient();
             String file="/home/xxx/videos/test.mp4"; // <-- Change to local video file
             String referenceId="ref_test_1234s";
             MediaType mediaType=MediaType.VIDEO;
@@ -100,7 +107,7 @@ public class KalturaApiIntegrationTest {
             assertNotNull(kalturaId);
      }
         
-    private DsKalturaClient getClientSession() throws IOException {
+    private DsKalturaClient getClient() throws IOException {
         final YAML conf = ServiceConfig.getConfig().getSubMap("kaltura");
         return new DsKalturaClient(
                 conf.getString("url"),

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -23,13 +23,31 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Unittest that will call the API search method. Search for a local refenceId to get the Kaltura internal id for the record.
  * Using Kaltura client v.19.3.3 there is no longer sporadic errors when calling the API.
- * 
+ *
  */
 @Tag("integration")
 public class KalturaApiIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(KalturaApiIntegrationTest.class);
-    
+
     private static final long DEFAULT_KEEP_ALIVE = 86400;
+
+    // ID's valid as of 2024-04-25 but subject to change
+    // TODO: Add a step to setup() creating test kaltura<->reference IDs 
+    public static final String KALTURA_ID1 = "0_84jdv1bw";
+    public static final String KALTURA_ID2 = "0_ahzrnnyh";
+    public static final String KALTURA_ID3 = "0_vbv44dk7";
+    public static final String REFERENCE_ID1 = "9ac77346-32d5-4733-b38f-91dd25649f88";
+    public static final String REFERENCE_ID2 = "108c27ed-4e7a-4d4b-8674-9fee57ab925f";
+    public static final String REFERENCE_ID3 = "89fbdd2e-82b1-483a-99d7-810101ef33b2";
+    // referenceID, kalturaID
+    public static final List<List<String>> KNOWN_PAIRS_NEW = List.of(
+            List.of(REFERENCE_ID1, KALTURA_ID1),
+            List.of(REFERENCE_ID2, KALTURA_ID2),
+            List.of(REFERENCE_ID3, KALTURA_ID3)
+    );
+    public static final List<List<String>> KNOWN_PAIRS = List.of(
+            List.of("7f7ffcbc-58dc-40bd-8ca9-12d0f9cf3ed7", "0_vvp1ozjl")
+    );
 
     @BeforeAll
     public static void setup() throws IOException {
@@ -41,25 +59,31 @@ public class KalturaApiIntegrationTest {
     }
 
     @Test
-    public void multipleLookups() throws IOException {
-        //These data can change in Kaltura
-        String referenceId="7f7ffcbc-58dc-40bd-8ca9-12d0f9cf3ed7";
-        String kalturaInternallId="0_vvp1ozjl";
+    public void kalturaIDsLookup() throws IOException {
+        Map<String, String> map = getClient().getKulturaIds(
+                KNOWN_PAIRS.stream().map(e -> e.get(0)).collect(Collectors.toList()));
+        log.debug("kalturaIDsLookup() got {} results from {} IDs", map.size(), KNOWN_PAIRS.size());
 
+        for (List<String> knownPair: KNOWN_PAIRS) {
+            String refID = knownPair.get(0);
+            String kalID = knownPair.get(1);
+            assertTrue(map.containsKey(refID), "There should be a mapping for referenceId '" + refID + "'");
+            assertEquals(kalID, map.get(refID), "The mapping for '" + refID + " should be as expected");
+        }
+    }
 
-        List<List<String>> tests = List.of(
-                List.of(referenceId,kalturaInternallId)
-        );
+    // We have no scenario where this lookup is used
+    @Test
+    public void referenceIDsLookup() throws IOException {
+        Map<String, String> map = getClient().getReferenceIds(
+                KNOWN_PAIRS.stream().map(e -> e.get(1)).collect(Collectors.toList()));
+        log.debug("referenceIDsLookup() got {} hits for {} kalturaIDs", map.size(), KNOWN_PAIRS.size());
 
-        DsKalturaClient clientSession = getClient();
-        Map<String, String> map = clientSession.getKulturaInternalIds(
-                tests.stream().map(e -> e.get(0)).collect(Collectors.toList()));
-
-        for (List<String> test: tests) {
+        for (List<String> test: KNOWN_PAIRS) {
             String refID = test.get(0);
             String kalID = test.get(1);
-          assertTrue(map.containsKey(refID), "There should be a mapping for referenceId '" + refID + "'");
-          assertEquals(kalID, map.get(refID), "The mapping for '" + refID + " should be as expected");
+            assertTrue(map.containsKey(kalID), "There should be a mapping for kalturaId '" + kalID + "'");
+            assertEquals(refID, map.get(kalID), "The mapping for '" + kalID + " should be as expected");
         }
     }
 
@@ -72,41 +96,41 @@ public class KalturaApiIntegrationTest {
 
     @Test
     public void callKalturaApi() throws Exception{
-                               
+
         //These data can change in Kaltura
-        String referenceId="7f7ffcbc-58dc-40bd-8ca9-12d0f9cf3ed7"; 
+        String referenceId="7f7ffcbc-58dc-40bd-8ca9-12d0f9cf3ed7";
         String kalturaInternallId="0_vvp1ozjl";
 
         DsKalturaClient clientSession= getClient();
-        
+
         int success=0;
-        for (int i = 0;i<10;i++) {                  
+        for (int i = 0;i<10;i++) {
             String kalturaId = clientSession.getKulturaInternalId(referenceId);
             assertEquals(kalturaInternallId, kalturaId,"API error was reproduced after "+success+" number of calls");
             log.debug("API returned internal Kaltura id:"+kalturaId);
-            success++;            
-            Thread.sleep(1000L);                        
-        }        
+            success++;
+            Thread.sleep(1000L);
+        }
     }
-    
-    
+
+
     /**
      * When uploading a file to Kaltura, remember to delete it from the Kaltura 
-     * 
+     *
      */
     @Test
-    public void kalturaUpload() throws Exception{                             
-            DsKalturaClient clientSession= getClient();
-            String file="/home/xxx/videos/test.mp4"; // <-- Change to local video file
-            String referenceId="ref_test_1234s";
-            MediaType mediaType=MediaType.VIDEO;
-            String tag="DS-KALTURA"; //This tag is use for all upload from DS to Kaltura
-            String title="test2 title from unittest";
-            String description="test2 description from unittest";            
-            String kalturaId = clientSession.uploadMedia(file, referenceId,mediaType,title,description,tag);   
-            assertNotNull(kalturaId);
-     }
-        
+    public void kalturaUpload() throws Exception{
+        DsKalturaClient clientSession= getClient();
+        String file="/home/xxx/videos/test.mp4"; // <-- Change to local video file
+        String referenceId="ref_test_1234s";
+        MediaType mediaType=MediaType.VIDEO;
+        String tag="DS-KALTURA"; //This tag is use for all upload from DS to Kaltura
+        String title="test2 title from unittest";
+        String description="test2 description from unittest";
+        String kalturaId = clientSession.uploadMedia(file, referenceId,mediaType,title,description,tag);
+        assertNotNull(kalturaId);
+    }
+
     private DsKalturaClient getClient() throws IOException {
         final YAML conf = ServiceConfig.getConfig().getSubMap("kaltura");
         return new DsKalturaClient(
@@ -116,5 +140,5 @@ public class KalturaApiIntegrationTest {
                 conf.getString("adminSecret"),
                 conf.getLong("sessionKeepAliveSeconds", DEFAULT_KEEP_ALIVE));
     }
-    
+
 }

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -1,10 +1,9 @@
 package dk.kb.kaltura;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import dk.kb.kaltura.config.ServiceConfig;
 import dk.kb.util.yaml.YAML;
@@ -17,6 +16,8 @@ import org.slf4j.LoggerFactory;
 import com.kaltura.client.enums.MediaType;
 
 import dk.kb.kaltura.client.DsKalturaClient;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 /**
@@ -45,8 +46,21 @@ public class KalturaApiIntegrationTest {
         String referenceId="7f7ffcbc-58dc-40bd-8ca9-12d0f9cf3ed7";
         String kalturaInternallId="0_vvp1ozjl";
 
+
+        List<List<String>> tests = List.of(
+                List.of(referenceId,kalturaInternallId)
+        );
+
         DsKalturaClient clientSession = getClientSession();
-        System.out.println(clientSession.getKulturaInternalIds(List.of("dr")).replace("{", "\n{"));
+        Map<String, String> map = clientSession.getKulturaInternalIds(
+                tests.stream().map(e -> e.get(0)).collect(Collectors.toList()));
+
+        for (List<String> test: tests) {
+            String refID = test.get(0);
+            String kalID = test.get(1);
+          assertTrue(map.containsKey(refID), "There should be a mapping for referenceId '" + refID + "'");
+          assertEquals(kalID, map.get(refID), "The mapping for '" + refID + " should be as expected");
+        }
     }
 
     @Test


### PR DESCRIPTION
This pull request adds `DsKalturaClient.getReferenceIDs` for bulk mapping of `referenceIDs` to `kalturaIDs`. This is needed for efficient map building for [ds-storage](https://github.com/kb-dk/ds-storage/).

This pull request is currently a draft as more functionality is expected to be added.

Bonus changes:

* Bugfix of timeout where the old code timed out almost immediately, effectively creating a new session for each request
* Cleanup of integration test code making it support properties
* Reverse `referenceIDs` -> `kalturaID` lookup
* Simple term based search for experimenting: `DsKalturaClient.searchTerm`