### PR TITLE
Fix startApptokenSession SessionType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-
+### Changed
+- Kaltura AppToken Client changed to use enum types (values) to start session. This was required since Kaltura was changed.
 
 ### Added
 - Method to reject a stream in Kaltura. The stream can not be played with rejected status. A KMC moderator can

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -522,12 +522,15 @@ public class DsKalturaClient {
         return "";
     }
 
-    private String startAppTokenSession(String hash, Client client, String tokenId) {
+    private String startAppTokenSession(String hash, Client client, String tokenId) throws APIException {
         AppTokenService.StartSessionAppTokenBuilder sessionBuilder =
-                AppTokenService.startSession(tokenId, hash);
-        sessionBuilder.type(SessionType.ADMIN.name());
+                AppTokenService.startSession(tokenId, hash,null,SessionType.ADMIN);
         Response<SessionInfo> response = (Response<SessionInfo>)
                 APIOkRequestsExecutor.getExecutor().execute(sessionBuilder.build(client));
+        if(!response.isSuccess()){
+            log.debug(response.error.getMessage());
+            throw response.error;
+        }
         return response.results.getKs();
     }
 

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -70,6 +70,11 @@ public class KalturaApiIntegrationTest {
     }
 
     @Test
+    public void testKalturaSession() throws Exception {
+        DsKalturaClient clientSession = getClient();
+    }
+
+    @Test
     public void kalturaIDsLookup() throws IOException {
         Map<String, String> map = getClient().getKulturaIds(
                 KNOWN_PAIRS.stream().map(e -> e.get(0)).collect(Collectors.toList()));


### PR DESCRIPTION
Fixes startApptokenSession using SessionType enum name instead of value. 
Added better error handling.
Added simple startSession test.