### PR TITLE
refactor-dsKalturaClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Extracted methods from uploadMedia to make individual steps/api calls in the uploadprocess more visible and easier 
+to maintain.
+- startClientSession have been refactored and now only starts a widget session appTokens is used. 
+- computeHash method no longer set attributes in the kaltura client and only computes the hash value.
+- Added API exceptions to upload and other methods using API calls.
+- Corrected spelling error in method name getKulturaInternalId to getKalturaInternalId.
+
+### Changed
 - Kaltura AppToken Client changed to use enum types (values) to start session. This was required since Kaltura was changed.
 - Kaltura upload will validate stream was connected to meta-data and throw IOException if last call (#4 out of 4) is not a success
+- Extracted methods from uploadMedia to make individual steps/api calls in the uploadprocess more visible and easier
+    to maintain.
+- startClientSession have been refactored and now only starts a widget session appTokens is used.
+- computeHash method no longer set attributes in the kaltura client and only computes the hash value.
+- Added API exceptions to upload and other methods using API calls.
+- Corrected spelling error in method name getKulturaInternalId to getKalturaInternalId.
 
 ### Added
 - Method to reject a stream in Kaltura. The stream can not be played with rejected status. A KMC moderator can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Extracted methods from uploadMedia to make individual steps/api calls in the uploadprocess more visible and easier 
-to maintain.
-- startClientSession have been refactored and now only starts a widget session appTokens is used. 
-- computeHash method no longer set attributes in the kaltura client and only computes the hash value.
-- Added API exceptions to upload and other methods using API calls.
-- Corrected spelling error in method name getKulturaInternalId to getKalturaInternalId.
-
-### Changed
 - Kaltura AppToken Client changed to use enum types (values) to start session. This was required since Kaltura was changed.
 - Kaltura upload will validate stream was connected to meta-data and throw IOException if last call (#4 out of 4) is not a success
 - Extracted methods from uploadMedia to make individual steps/api calls in the uploadprocess more visible and easier

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -187,7 +187,7 @@ public class DsKalturaClient {
      *         Unresolvable {@code referenceIDs} will not be present in the map.
      * @throws IOException if the remote request failed.
      */
-    public Map<String, String> getKalturaIds(List<String> referenceIds) throws IOException{
+    public Map<String, String> getKalturaIds(List<String> referenceIds) throws IOException, APIException {
         if (referenceIds.isEmpty()) {
             log.info("getKulturaInternalIds(referenceIDs) called with empty list of IDs");
             return Collections.emptyMap();
@@ -240,7 +240,7 @@ public class DsKalturaClient {
      * @return a list of Kaltura IDs for matching records, empty if no hits. Max result size is {@link #BATCH_SIZE}.
      * @throws IOException if the remote request failed.
      */
-    public List<String> searchTerm(String term) throws IOException{
+    public List<String> searchTerm(String term) throws IOException, APIException {
         // Adapted from Java samples at https://developer.kaltura.com
         // https://developer.kaltura.com/console/service/eSearch/action/searchEntry?query=search
         // https://developer.kaltura.com/api-docs/Search--Discover-and-Personalize/esearch.html
@@ -264,7 +264,7 @@ public class DsKalturaClient {
      * @throws IOException if the remote request failed.
      */
     @SuppressWarnings("unchecked")
-    private Response<ESearchEntryResponse> searchMulti(List<ESearchEntryBaseItem> items) throws IOException{
+    private Response<ESearchEntryResponse> searchMulti(List<ESearchEntryBaseItem> items) throws IOException, APIException {
         // Adapted from Java samples at https://developer.kaltura.com
         // https://developer.kaltura.com/console/service/eSearch/action/searchEntry?query=search
         // https://developer.kaltura.com/api-docs/Search--Discover-and-Personalize/esearch.html
@@ -287,8 +287,14 @@ public class DsKalturaClient {
 
         // Issue search
         ESearchService.SearchEntryESearchBuilder requestBuilder = ESearchService.searchEntry(searchParams, pager);
-        return (Response<ESearchEntryResponse>)
+        Response<ESearchEntryResponse> response = (Response<ESearchEntryResponse>)
                 APIOkRequestsExecutor.getExecutor().execute(requestBuilder.build(getClientInstance()));
+
+        if(!response.isSuccess()){
+            log.debug(response.error.getMessage());
+            throw response.error;
+        }
+        return response;
     }
 
     /**

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -205,7 +205,7 @@ public class DsKalturaClient {
                 .forEach(entry -> {
                     String previousID;
                     if ((previousID = pairs.put(entry.getReferenceId(), entry.getId())) != null) {
-                        log.warn("Warning: referenceID '{}' resolved to multiple kalturaIDs [\"{}\", \"{}\"]",
+                        log.warn("Warning: referenceID '{}' resolved to multiple kalturaIDs ['{}', '{}']",
                                 entry.getReferenceId(), previousID, entry.getId());
                     }});
         return pairs;
@@ -339,10 +339,10 @@ public class DsKalturaClient {
                 APIOkRequestsExecutor.getExecutor().execute(uploadTokenRequestBuilder.build(clientsession));
 
         if (response.isSuccess()) {
-            log.debug("UploadToken \"{}\" successfully added.", response.results.getId());
+            log.debug("UploadToken '{}' successfully added.", response.results.getId());
             return response.results.getId();
         }else{
-            log.debug("Adding uploadToken failed because: \"{}\"", response.error.getMessage());
+            log.debug("Adding uploadToken failed because: '{}'", response.error.getMessage());
             throw response.error;
         }
     }
@@ -378,11 +378,11 @@ public class DsKalturaClient {
         Response<UploadToken> response =
                 (Response<UploadToken> ) APIOkRequestsExecutor.getExecutor().execute(uploadBuilder.build(client));
         if (response.isSuccess()) {
-            log.debug("File \"{}\" uploaded successfully to upload token \"{}\".", filePath,
+            log.debug("File '{}' uploaded successfully to upload token '{}'.", filePath,
                     response.results.getId());
             return response.results.getId();
         } else {
-            log.debug("Failed to upload file \"{}\" to upload token \"{}\" because: \"{}\"", filePath,
+            log.debug("Failed to upload file '{}' to upload token '{}' because: '{}'", filePath,
                     uploadTokenId, response.error.getMessage());
             throw response.error;
         }
@@ -418,10 +418,10 @@ public class DsKalturaClient {
         Response <MediaEntry> response = (Response <MediaEntry>)  APIOkRequestsExecutor.getExecutor().execute(addEntryBuilder.build(clientSession)); // No need for return object
 
         if(response.isSuccess()) {
-            log.debug("Added entry \"{}\" successfully.", response.results.getId());
+            log.debug("Added entry '{}' successfully.", response.results.getId());
             return response.results.getId();
         }else{
-            log.debug("Failed to add entry with reference ID \"{}\" because: \"{}\"", referenceId,
+            log.debug("Failed to add entry with reference ID '{}' because: '{}'", referenceId,
                     response.error.getMessage());
             throw response.error;
         }
@@ -460,10 +460,10 @@ public class DsKalturaClient {
 
         Response<MediaEntry> response = (Response<MediaEntry>) APIOkRequestsExecutor.getExecutor().execute(requestBuilder.build(clientSession));
         if(response.isSuccess()){
-            log.debug("UploadToken \"{}\" was added to entry \"{}\"", uploadtokenId, entryId);
+            log.debug("UploadToken '{}' was added to entry '{}'", uploadtokenId, entryId);
             return response.results.getId();
         }else{
-            log.debug("UploadToken \"{}\" was not added to entry \"{}\" because: \"{}\"", uploadtokenId, entryId,
+            log.debug("UploadToken '{}' was not added to entry '{}' because: '{}'", uploadtokenId, entryId,
                     response.error.getMessage());
             throw response.error;
         }

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -329,7 +329,7 @@ public class DsKalturaClient {
             log.debug("UploadToken \"{}\" successfully added.", response.results.getId());
             return response.results.getId();
         }else{
-            log.error("Adding uploadToken failed because: \"{}\"", response.error.getMessage());
+            log.debug("Adding uploadToken failed because: \"{}\"", response.error.getMessage());
             throw response.error;
         }
     }
@@ -360,7 +360,7 @@ public class DsKalturaClient {
                     response.results.getId());
             return response.results.getId();
         } else {
-            log.error("Failed to upload file \"{}\" to upload token \"{}\" because: \"{}\"", filePath,
+            log.debug("Failed to upload file \"{}\" to upload token \"{}\" because: \"{}\"", filePath,
                     uploadTokenId, response.error.getMessage());
             throw response.error;
         }
@@ -387,7 +387,8 @@ public class DsKalturaClient {
             log.debug("Added entry \"{}\" successfully.", response.results.getId());
             return response.results.getId();
         }else{
-            log.error("Failed to add entry with reference ID \"{}\" because: \"{}\"", referenceId, response.error.getMessage());
+            log.debug("Failed to add entry with reference ID \"{}\" because: \"{}\"", referenceId,
+                    response.error.getMessage());
             throw response.error;
         }
 
@@ -415,7 +416,7 @@ public class DsKalturaClient {
             log.debug("UploadToken \"{}\" was added to entry \"{}\"", uploadtokenId, entryId);
             return response.results.getId();
         }else{
-            log.error("UploadToken \"{}\" was not added to entry \"{}\" because: \"{}\"", uploadtokenId, entryId,
+            log.debug("UploadToken \"{}\" was not added to entry \"{}\" because: \"{}\"", uploadtokenId, entryId,
                     response.error.getMessage());
             throw response.error;
         }
@@ -477,7 +478,6 @@ public class DsKalturaClient {
      * @return The internal id for the Kaltura record. Example format: '0_jqmzfljb'
      * @throws IOException the io exception
      */
-    @SuppressWarnings("unchecked")
     public String uploadMedia(String filePath, String referenceId, MediaType mediaType,
     String title,String description, String tag, Integer flavorParamId) throws IOException, APIException {
 
@@ -489,19 +489,15 @@ public class DsKalturaClient {
             throw new IllegalArgumentException("Kaltura mediaType must be defined");            
         }
 
-        try{
-            String uploadTokenId = addUploadToken();
+        String uploadTokenId = addUploadToken();
 
-            uploadFile(uploadTokenId, filePath);
+        uploadFile(uploadTokenId, filePath);
 
-            String entryId = addEmptyEntry(mediaType, title, description, referenceId, tag);
+        String entryId = addEmptyEntry(mediaType, title, description, referenceId, tag);
 
-            return addContentToEntry(uploadTokenId, entryId, flavorParamId);
+        addContentToEntry(uploadTokenId, entryId, flavorParamId);
 
-        }catch (APIException e) {
-            log.error("Failed to uploadMedia filePath \"{}\" with referenceId \"{}\" because: \"{}\"", filePath, referenceId, e.getMessage());
-            throw e;
-        }
+        return entryId;
     }
 
     /**

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -140,7 +140,7 @@ public class DsKalturaClient {
      * @throws IOException if Kaltura called failed, or more than 1 entry was found with the referenceId.
      */
     @SuppressWarnings("unchecked")
-    public String getKulturaInternalId(String referenceId) throws IOException{
+    public String getKalturaInternalId(String referenceId) throws IOException{
 
         Client clientSession = getClientInstance();
 
@@ -446,10 +446,8 @@ public class DsKalturaClient {
      * @return The internal id for the Kaltura record. Example format: '0_jqmzfljb'
      * @throws IOException the io exception
      */
-    public String uploadMedia(String filePath, String referenceId, MediaType mediaType,
-                                                  String title,
-                                       String description,
-                                                    String tag) throws IOException, InterruptedException, APIException {
+    public String uploadMedia(String filePath, String referenceId, MediaType mediaType, String title, String description,
+                              String tag) throws IOException, APIException {
         return uploadMedia(filePath, referenceId, mediaType, title, description, tag, null);
     }
 

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -218,7 +218,7 @@ public class DsKalturaClient {
      *         Unresolvable {@code kalturaIDs} will not be present in the map.
      * @throws IOException if the remote request failed.
      */
-    public Map<String, String> getReferenceIds(List<String> kalturaIDs) throws IOException{
+    public Map<String, String> getReferenceIds(List<String> kalturaIDs) throws IOException, APIException {
         if (kalturaIDs.isEmpty()) {
             log.info("getReferenceIds(kalturaIDs) called with empty list of IDs");
             return Collections.emptyMap();

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -148,7 +148,8 @@ public class DsKalturaClient {
         filter.setReferenceIdEqual(referenceId);
 
         FilterPager pager = new FilterPager();
-        pager.setPageIndex(10);
+        pager.setPageIndex(1);
+        pager.setPageSize(BATCH_SIZE);
 
         ListMediaBuilder request =  MediaService.list(filter);               
 
@@ -186,7 +187,7 @@ public class DsKalturaClient {
      *         Unresolvable {@code referenceIDs} will not be present in the map.
      * @throws IOException if the remote request failed.
      */
-    public Map<String, String> getKulturaIds(List<String> referenceIds) throws IOException{
+    public Map<String, String> getKalturaIds(List<String> referenceIds) throws IOException{
         if (referenceIds.isEmpty()) {
             log.info("getKulturaInternalIds(referenceIDs) called with empty list of IDs");
             return Collections.emptyMap();
@@ -316,6 +317,110 @@ public class DsKalturaClient {
         return item;
     }
 
+    private String addUploadToken() throws IOException, APIException {
+        //Get a token that will allow upload
+        Client clientsession = getClientInstance();
+        UploadToken uploadToken = new UploadToken();
+        AddUploadTokenBuilder uploadTokenRequestBuilder = UploadTokenService.add(uploadToken);
+        Response<UploadToken> response = (Response<UploadToken>)
+                APIOkRequestsExecutor.getExecutor().execute(uploadTokenRequestBuilder.build(clientsession));
+
+        if (response.isSuccess()) {
+            log.debug("UploadToken \"{}\" successfully added.", response.results.getId());
+            return response.results.getId();
+        }else{
+            log.error("Adding uploadToken failed because: \"{}\"", response.error.getMessage());
+            throw response.error;
+        }
+    }
+
+    private String uploadFile(String uploadTokenId, String filePath) throws IOException, APIException {
+        Client client = getClientInstance();
+
+        //Upload the file using the upload token.
+        File fileData = new File(filePath);
+        boolean resume = false;
+        boolean finalChunk = true;
+        int resumeAt = -1;
+
+        if (!fileData.exists() & !fileData.canRead()) {
+            try {
+                throw new IOException(filePath + " not accessible");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        UploadUploadTokenBuilder uploadBuilder = UploadTokenService.upload(uploadTokenId, fileData, resume, finalChunk,
+                resumeAt);
+        Response<UploadToken> response =
+                (Response<UploadToken> ) APIOkRequestsExecutor.getExecutor().execute(uploadBuilder.build(client));
+        if (response.isSuccess()) {
+            log.debug("File \"{}\" uploaded successfully to upload token \"{}\".", filePath,
+                    response.results.getId());
+            return response.results.getId();
+        } else {
+            log.error("Failed to upload file \"{}\" to upload token \"{}\" because: \"{}\"", filePath,
+                    uploadTokenId, response.error.getMessage());
+            throw response.error;
+        }
+
+    }
+
+    private String addEmptyEntry(MediaType mediaType, String title, String description, String referenceId, String tag) throws IOException, APIException {
+        Client clientSession = getClientInstance();
+
+        //Create entry with meta data
+        MediaEntry entry = new MediaEntry();
+        entry.setMediaType(mediaType);
+        entry.setName(title);
+        entry.setDescription(description);
+        entry.setReferenceId(referenceId);
+        if(tag != null) {
+            entry.setTags(tag);
+        }
+
+        AddMediaBuilder addEntryBuilder = MediaService.add(entry);
+        Response <MediaEntry> response = (Response <MediaEntry>)  APIOkRequestsExecutor.getExecutor().execute(addEntryBuilder.build(clientSession)); // No need for return object
+
+        if(response.isSuccess()) {
+            log.debug("Added entry \"{}\" successfully.", response.results.getId());
+            return response.results.getId();
+        }else{
+            log.error("Failed to add entry with reference ID \"{}\" because: \"{}\"", referenceId, response.error.getMessage());
+            throw response.error;
+        }
+
+    }
+
+    private String addContentToEntry(String uploadtokenId, String entryId, Integer flavorParamId) throws APIException, IOException {
+
+        Client clientSession = getClientInstance();
+        //Connect uploaded file with meta data entry
+        UploadedFileTokenResource resource = new UploadedFileTokenResource();
+        resource.setToken(uploadtokenId);
+        AddContentMediaBuilder requestBuilder;
+
+        if( flavorParamId == null){
+            requestBuilder = MediaService.addContent(entryId, resource);
+        }else{
+            AssetParamsResourceContainer paramContainer = new AssetParamsResourceContainer();
+            paramContainer.setAssetParamsId(flavorParamId);
+            paramContainer.setResource(resource);
+            requestBuilder = MediaService.addContent(entryId, paramContainer);
+        }
+
+        Response<MediaEntry> response = (Response<MediaEntry>) APIOkRequestsExecutor.getExecutor().execute(requestBuilder.build(clientSession));
+        if(response.isSuccess()){
+            log.debug("UploadToken \"{}\" was added to entry \"{}\"", uploadtokenId, entryId);
+            return response.results.getId();
+        }else{
+            log.error("UploadToken \"{}\" was not added to entry \"{}\" because: \"{}\"", uploadtokenId, entryId,
+                    response.error.getMessage());
+            throw response.error;
+        }
+    }
+
     /**
      * Upload a video or audio file to Kaltura.
      * The upload require 4 API calls to Kaltura
@@ -340,8 +445,10 @@ public class DsKalturaClient {
      * @return The internal id for the Kaltura record. Example format: '0_jqmzfljb'
      * @throws IOException the io exception
      */
-    public String uploadMedia(String filePath, String referenceId, MediaType mediaType, String title, String description,
-                              String tag) throws IOException{
+    public String uploadMedia(String filePath, String referenceId, MediaType mediaType,
+                                                  String title,
+                                       String description,
+                                                    String tag) throws IOException, InterruptedException, APIException {
         return uploadMedia(filePath, referenceId, mediaType, title, description, tag, null);
     }
 
@@ -371,8 +478,8 @@ public class DsKalturaClient {
      * @throws IOException the io exception
      */
     @SuppressWarnings("unchecked")
-    public String uploadMedia(String filePath, String referenceId, MediaType mediaType, String title, String description,
-                              String tag, Integer flavorParamId) throws IOException{
+    public String uploadMedia(String filePath, String referenceId, MediaType mediaType,
+    String title,String description, String tag, Integer flavorParamId) throws IOException, APIException {
 
         if (referenceId== null) {
             throw new IllegalArgumentException("referenceId must be defined");            
@@ -382,56 +489,19 @@ public class DsKalturaClient {
             throw new IllegalArgumentException("Kaltura mediaType must be defined");            
         }
 
-        Client clientSession = getClientInstance();
+        try{
+            String uploadTokenId = addUploadToken();
 
-        //Get a token that will allow upload        
-        UploadToken uploadToken = new UploadToken();
-        AddUploadTokenBuilder uploadTokenRequestBuilder = UploadTokenService.add(uploadToken);              
-        Response <UploadToken> response = (Response <UploadToken>) APIOkRequestsExecutor.getExecutor().execute(uploadTokenRequestBuilder.build(clientSession));        
-        String tokenId=response.results.getId();
+            uploadFile(uploadTokenId, filePath);
 
-        //Upload the file using the upload token.        
-        File fileData = new File(filePath);
-        boolean resume = false;
-        boolean finalChunk = true;
-        int resumeAt = -1;
+            String entryId = addEmptyEntry(mediaType, title, description, referenceId, tag);
 
-        UploadUploadTokenBuilder uploadBuilder = UploadTokenService.upload(tokenId, fileData, resume, finalChunk, resumeAt);
-        APIOkRequestsExecutor.getExecutor().execute(uploadBuilder.build(clientSession)); //No need for return object
+            return addContentToEntry(uploadTokenId, entryId, flavorParamId);
 
-        //Create entry with meta data       
-        MediaEntry entry = new MediaEntry();
-        entry.setMediaType(mediaType);
-        entry.setName(title);
-        entry.setDescription(description);
-        entry.setReferenceId(referenceId);
-        if(tag != null) {
-            entry.setTags(tag);
+        }catch (APIException e) {
+            log.error("Failed to uploadMedia filePath \"{}\" with referenceId \"{}\" because: \"{}\"", filePath, referenceId, e.getMessage());
+            throw e;
         }
-
-        AddMediaBuilder addEntryBuilder = MediaService.add(entry);   
-        Response <MediaEntry> response1 = (Response <MediaEntry>)  APIOkRequestsExecutor.getExecutor().execute(addEntryBuilder.build(clientSession)); // No need for return object
-        String entryId= response1.results.getId();
-
-        //Connect uploaded file with meta data entry       
-        UploadedFileTokenResource resource = new UploadedFileTokenResource();
-        resource.setToken(tokenId);
-
-        AddContentMediaBuilder requestBuilder;
-        if( flavorParamId == null){
-            requestBuilder = MediaService.addContent(entryId, resource);
-        }else{
-            AssetParamsResourceContainer paramContainer = new AssetParamsResourceContainer();
-            paramContainer.setAssetParamsId(flavorParamId);
-            paramContainer.setResource(resource);
-            requestBuilder = MediaService.addContent(entryId, paramContainer);
-        }
-        Response<?> res = APIOkRequestsExecutor.getExecutor().execute(requestBuilder.build(clientSession));
-        if (!res.isSuccess()) {
-            throw new IOException("Error in kaltura upload connecting meta-data to stream. Entry id:"+entryId);
-        }
-
-        return entryId;
     }
 
     /**

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -555,7 +555,6 @@ public class DsKalturaClient {
             if (this.client == null || System.currentTimeMillis()-lastSessionStart >= sessionKeepAliveSeconds*1000) {
                 log.info("Refreshing Kaltura client session, millis since last refresh:"+(System.currentTimeMillis()-lastSessionStart));
                 //Create the client
-                //KalturaConfiguration config = new KalturaConfiguration();
                 Configuration config = new Configuration();
                 config.setEndpoint(kalturaUrl);
                 Client client = new Client(config);

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -437,7 +437,7 @@ public class DsKalturaClient {
      * @param uploadtokenId Upload token with content
      * @param entryId Entry to receive content
      * @param flavorParamId Id of the flavorParam where the content needs to be added within the Entry.
-     * @return FlavorID's at given Entry
+     * @return EntryId of updated entry
      * @throws APIException
      * @throws IOException
      */

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -620,9 +620,11 @@ public class DsKalturaClient {
      *
      * @param token AppToken String for computing hash
      * @param ks Kaltura Widget Session for computing hash
-     * @return A string representing a SHA-256 tokenHash package or an empty string if Error Occurs.
+     * @return A string representing a SHA-256 tokenHash package.
+     * @throws UnsupportedEncodingException
+     * @throws NoSuchAlgorithmException
      */
-    private String computeHash(String token, String ks){
+    private String computeHash(String token, String ks) throws UnsupportedEncodingException, NoSuchAlgorithmException {
 
         try{
             MessageDigest md = MessageDigest.getInstance("SHA-256");
@@ -640,8 +642,8 @@ public class DsKalturaClient {
             return hashString.toString();
         }catch (NoSuchAlgorithmException | UnsupportedEncodingException e){
             log.warn("SHA-256 algorithm not available");
+            throw e;
         }
-        return "";
     }
 
     /**

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -513,7 +513,7 @@ public class DsKalturaClient {
         try {
 
 
-            if (client == null || System.currentTimeMillis()-lastSessionStart >= sessionKeepAliveSeconds*1000) {
+            if (this.client == null || System.currentTimeMillis()-lastSessionStart >= sessionKeepAliveSeconds*1000) {
                 log.info("Refreshing Kaltura client session, millis since last refresh:"+(System.currentTimeMillis()-lastSessionStart));
                 //Create the client
                 //KalturaConfiguration config = new KalturaConfiguration();
@@ -525,9 +525,9 @@ public class DsKalturaClient {
                 this.client=client;
                 lastSessionStart=System.currentTimeMillis(); //Reset timer
                 log.info("Refreshed Kaltura client session");
-                return client;
+                return this.client;
             }
-            return client; //Reuse existing connection.
+            return this.client; //Reuse existing connection.
         }
         catch (Exception e) {
             log.warn("Connecting to Kaltura failed. KalturaUrl={},error={}",kalturaUrl,e.getMessage());
@@ -596,7 +596,7 @@ public class DsKalturaClient {
     private String generateAppTokenSession(Client client, String tokenId, String token) throws APIException {
         String widgetSession = startWidgetSession(client);
         client.setKs(widgetSession);
-        client.setSessionId(widgetSession);
+//        client.setSessionId(widgetSession);
         String hash = computeHash(token, widgetSession);
         return startAppTokenSession(client, tokenId, hash);
     }

--- a/src/main/java/dk/kb/kaltura/jobs/IdLookup.java
+++ b/src/main/java/dk/kb/kaltura/jobs/IdLookup.java
@@ -36,7 +36,7 @@ public class IdLookup extends JobsBase implements Callable<Integer>{
     public Integer call() throws Exception {        
 
        DsKalturaClient kalturaClient = getKalturaClient();
-       String kalturaId=kalturaClient.getKulturaInternalId(referenceId); 
+       String kalturaId=kalturaClient.getKalturaInternalId(referenceId);
        String message="ReferenceId:"+referenceId +" -> kalturaId:"+kalturaId;
        log.info(message);
        System.out.println(message);

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -91,7 +91,7 @@ public class KalturaApiIntegrationTest {
 
     // We have no scenario where this lookup is used
     @Test
-    public void referenceIDsLookup() throws IOException {
+    public void referenceIDsLookup() throws IOException, APIException {
         Map<String, String> map = getClient().getReferenceIds(
                 KNOWN_PAIRS.stream().map(e -> e.get(1)).collect(Collectors.toList()));
         log.debug("referenceIDsLookup() got {} hits for {} kalturaIDs", map.size(), KNOWN_PAIRS.size());

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.kaltura.client.types.APIException;
 import com.kaltura.client.types.AppToken;
 import dk.kb.kaltura.client.AppTokenClient;
 import dk.kb.kaltura.config.ServiceConfig;
@@ -75,7 +76,7 @@ public class KalturaApiIntegrationTest {
     }
 
     @Test
-    public void kalturaIDsLookup() throws IOException {
+    public void kalturaIDsLookup() throws IOException, APIException {
         Map<String, String> map = getClient().getKalturaIds(
                 KNOWN_PAIRS.stream().map(e -> e.get(0)).collect(Collectors.toList()));
         log.debug("kalturaIDsLookup() got {} results from {} IDs", map.size(), KNOWN_PAIRS.size());
@@ -104,7 +105,7 @@ public class KalturaApiIntegrationTest {
     }
 
     @Test
-    public void simpleSearch() throws IOException {
+    public void simpleSearch() throws IOException, APIException {
         List<String> ids = getClient().searchTerm("dr");
         assertFalse(ids.isEmpty(), "Search result should not be empty");
         System.out.println(ids);

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -182,6 +182,10 @@ public class KalturaApiIntegrationTest {
         Integer flavorParamId = 3; // <-- Change according to MediaType. 3 for lowQ video and 359 for audio
         String kalturaId = clientSession.uploadMedia(file,referenceId,mediaType,title,description,tag, flavorParamId);
         assertNotNull(kalturaId);
+        MediaService.GetMediaBuilder getMediaBuilder = MediaService.get(kalturaId);
+        Response<MediaEntry> response1;
+        response1 = (Response<MediaEntry>) APIOkRequestsExecutor.getExecutor().execute(getMediaBuilder.build(clientSession.getClient()));
+        assertTrue(response1.isSuccess());
     }
 
     @Test

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -76,7 +76,7 @@ public class KalturaApiIntegrationTest {
 
     @Test
     public void kalturaIDsLookup() throws IOException {
-        Map<String, String> map = getClient().getKulturaIds(
+        Map<String, String> map = getClient().getKalturaIds(
                 KNOWN_PAIRS.stream().map(e -> e.get(0)).collect(Collectors.toList()));
         log.debug("kalturaIDsLookup() got {} results from {} IDs", map.size(), KNOWN_PAIRS.size());
 
@@ -182,10 +182,6 @@ public class KalturaApiIntegrationTest {
         Integer flavorParamId = 3; // <-- Change according to MediaType. 3 for lowQ video and 359 for audio
         String kalturaId = clientSession.uploadMedia(file,referenceId,mediaType,title,description,tag, flavorParamId);
         assertNotNull(kalturaId);
-        MediaService.GetMediaBuilder getMediaBuilder = MediaService.get(kalturaId);
-        Response<MediaEntry> response1;
-        response1 = (Response<MediaEntry>) APIOkRequestsExecutor.getExecutor().execute(getMediaBuilder.build(clientSession.getClient()));
-        assertTrue(response1.isSuccess());
     }
 
     @Test

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -132,7 +132,7 @@ public class KalturaApiIntegrationTest {
 
         int success=0;
         for (int i = 0;i<10;i++) {
-            String kalturaId = clientSession.getKulturaInternalId(referenceId);
+            String kalturaId = clientSession.getKalturaInternalId(referenceId);
             assertEquals(kalturaInternallId, kalturaId,"API error was reproduced after "+success+" number of calls");
             log.debug("API returned internal Kaltura id:"+kalturaId);
             success++;


### PR DESCRIPTION
Mainly this refactor have exstracted methods from uploadMedia to make individual steps/api calls in the uploadprocess more apparent and easier to maintain. 
The startClientSesssion have also been refactored and now only starts a widget session if we use appTokens. Also compute hash does no longer set attributes in the kaltura client and only computes the hash value. 
Other smaller changes include more javadoc, correcting spelling errors, and adding API exceptions to upload and other methods using API calls.  