### PR TITLE
DRA-2018+2019-refresh-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config to use sessionDurationSeconds and sessionRefreshThreshold instead of keepAliveSeconds. 
   KeepAliveSeconds is now calculated from these two parameters and sessionDurationSeconds is used when starting a 
   session.
+- Changed KeepAliveSession from long to int.
 
 ### Added
 - Added getSessionInfo that logs sessionInfo. Only used for testing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   KeepAliveSeconds is now calculated from these two parameters and sessionDurationSeconds is used when starting a 
   session.
 - Changed KeepAliveSession from long to int.
+- Changed startWidgetSession to take a nullable Integer to set specific Expiry. This should not be lower than 600 
+  due to Kaltura caching of responses.  
 
 ### Added
 - Added getSessionInfo that logs sessionInfo. Only used for testing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Config to use sessionDurationSeconds and sessionRefreshThreshold instead of keepAliveSeconds. 
+  KeepAliveSeconds is now calculated from these two parameters and sessionDurationSeconds is used when starting a 
+  session.
 
 ### Added
+- Added getSessionInfo that logs sessionInfo. Only used for testing.
 
 ### Changed
 

--- a/src/main/conf/ds-kaltura-behaviour.yaml
+++ b/src/main/conf/ds-kaltura-behaviour.yaml
@@ -16,7 +16,8 @@ kaltura:
   userId:  'XXX@kb.dk'
   token: 'yyyyy'
   tokenId: 'yyyyy'
-  sessionKeepAliveSeconds: 86400
+  sessionDurationSeconds: 86400
+  sessionRefreshThreshold: 3600
 
 # The configuration can auto-update at set intervals. See ServiceConfig for details
 autoupdate:

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -633,7 +633,7 @@ public class DsKalturaClient {
         if(!response.isSuccess()){
             throw response.error;
         }
-        log.debug("widget session: {}", response.results.getKs());
+
         return response.results.getKs();
     }
 

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -31,10 +31,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 
@@ -667,7 +664,7 @@ public class DsKalturaClient {
                 .atZone(ZoneId.systemDefault())
                 .toLocalDateTime();
         // Format the LocalDateTime to a readable format
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.getDefault());
         String formattedDateTime = localDateTime.format(formatter);
 
         log.info("Session expiry: {}, Session type: {}, Privileges: {}", formattedDateTime,

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -86,18 +86,19 @@ public class DsKalturaClient {
      */
     public DsKalturaClient(String kalturaUrl, String userId, int partnerId, String token, String tokenId,
                            String adminSecret, int sessionDurationSeconds, int sessionRefreshThreshold) throws IOException {
-        this.sessionDurationSeconds=sessionDurationSeconds;
-        this.sessionRefreshThreshold=sessionRefreshThreshold;
-        this.sessionKeepAliveSeconds=sessionDurationSeconds-sessionRefreshThreshold;
-        this.kalturaUrl=kalturaUrl;
-        this.userId=userId;
-        this.token=token;
-        this.tokenId=tokenId;
-        this.adminSecret=adminSecret;
-        this.partnerId=partnerId;
+        this.sessionDurationSeconds = sessionDurationSeconds;
+        this.sessionRefreshThreshold = sessionRefreshThreshold;
+        this.sessionKeepAliveSeconds = sessionDurationSeconds-sessionRefreshThreshold;
+        this.kalturaUrl = kalturaUrl;
+        this.userId = userId;
+        this.token = token;
+        this.tokenId = tokenId;
+        this.adminSecret = adminSecret;
+        this.partnerId = partnerId;
 
-        if (sessionKeepAliveSeconds <600) { //Enforce some kind of reuse of session since authenticating sessions will accumulate at Kaltura.
-            throw new IllegalArgumentException("SessionKeepAliveSeconds must be at least 600 seconds (10 minutes) ");
+        if (sessionKeepAliveSeconds < 600) { //Enforce some kind of reuse of session since authenticating sessions
+            // will accumulate at Kaltura.
+            throw new IllegalArgumentException("The difference between the configured sessionDurationSeconds and sessionRefreshThreshold (SessionKeepAliveSession) must be at least 600 seconds (10 minutes) ");
         }
 
         getClientInstance();// Start a session already now so it will not fail later when used if credentials fails.
@@ -614,31 +615,26 @@ public class DsKalturaClient {
      *               server.
      * @return Kaltura Session
      */
-    public String startWidgetSession(Client client, @Nullable Integer expiry ) throws APIException {
+    private String startWidgetSession(Client client, @Nullable Integer expiry) throws APIException {
         log.debug("Generating Widget Session...");
         client.setKs(null);
         String widgetId = "_" + client.getPartnerId();
         SessionService.StartWidgetSessionSessionBuilder requestBuilder;
-        if(expiry == null) {
+        if (expiry == null) {
             requestBuilder = SessionService.startWidgetSession(widgetId);
-        }else{
+        } else {
             requestBuilder = SessionService.startWidgetSession(widgetId, expiry);
         }
         log.debug(requestBuilder.toString());
         Response<StartWidgetSessionResponse> response =
                 (Response<StartWidgetSessionResponse>) APIOkRequestsExecutor.getExecutor().execute(requestBuilder.build(client, true));
 
-        if(!response.isSuccess()){
+        if (!response.isSuccess()) {
             throw response.error;
         }
 
         return response.results.getKs();
     }
-
-    public String startWidgetSession(Client client) throws APIException, IOException {
-        return startWidgetSession(client, null);
-    }
-
 
     /**
      * logs SessionInfo response from SessionService.get(ks).
@@ -647,7 +643,7 @@ public class DsKalturaClient {
      * @throws APIException
      * @throws IOException
      */
-    public void getSessionInfo(String ks) throws APIException, IOException {
+    public void logSessionInfo(String ks) throws APIException, IOException {
 
         SessionService.GetSessionBuilder requestBuilder = SessionService.get(ks);
 
@@ -677,8 +673,8 @@ public class DsKalturaClient {
      * @throws APIException
      * @throws IOException
      */
-    public void getSessionInfo() throws APIException, IOException {
-        getSessionInfo(client.getKs());
+    public void logSessionInfo() throws APIException, IOException {
+        logSessionInfo(client.getKs());
     }
 
     /**

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -79,7 +79,9 @@ public class DsKalturaClient {
      * @param token The application token used for generating client sessions
      * @param tokenId The id of the application token
      * @param adminSecret The adminsecret used as password for authenticating. Must not be shared.
-     * @param sessionDurationSeconds Reuse the Kaltura Session for performance. Sessions will be refreshed at the given interval. Recommended value 86400 (1 day)
+     * @param sessionDurationSeconds The duration of Kaltura Session in seconds. Beware that when using AppTokens
+     *                               this might have an upper bound tied to the AppToken.
+     * @param sessionRefreshThreshold The threshold in seconds for session renewal.
      *
      * Either a token/tokenId a adminSecret must be provided for authentication.
      *
@@ -102,16 +104,6 @@ public class DsKalturaClient {
         }
 
         getClientInstance();// Start a session already now so it will not fail later when used if credentials fails.
-    }
-
-    public DsKalturaClient(String kalturaUrl, String userId, int partnerId, String token, String tokenId,
-                           String adminSecret, int sessionDurationSeconds) throws IOException {
-       this(kalturaUrl, userId, partnerId, token, tokenId,
-                adminSecret, sessionDurationSeconds, 0);
-    }
-
-    public Client getKalturaClient() {
-        return client;
     }
 
     /**

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -201,7 +201,6 @@ public class DsKalturaClient {
      * @throws IOException if the remote request failed.
      */
     public Map<String, String> getKalturaIds(List<String> referenceIds) throws IOException, APIException {
-        getClientInstance();
         if (referenceIds.isEmpty()) {
             log.info("getKulturaInternalIds(referenceIDs) called with empty list of IDs");
             return Collections.emptyMap();
@@ -752,4 +751,6 @@ public class DsKalturaClient {
         }
         return response.results.getKs();
     }
+
+
 }

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -614,9 +614,11 @@ public class DsKalturaClient {
     /**
      * Starts widgetSession with using a client.
      * @param client The Kaltura client. Needs to be initialized with config, endpoint and partner ID
+     * @param expiry The session duration in seconds. Should not be under 600 due to caching of response on Kaltura
+     *               server.
      * @return Kaltura Session
      */
-    public String startWidgetSession(Client client, @Nullable Integer expiry ) throws APIException, IOException {
+    public String startWidgetSession(Client client, @Nullable Integer expiry ) throws APIException {
         log.debug("Generating Widget Session...");
         client.setKs(null);
         String widgetId = "_" + client.getPartnerId();

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -21,11 +21,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -60,8 +65,10 @@ public class DsKalturaClient {
     private String token;
     private String tokenId;
     private String adminSecret;
-    private long sessionKeepAliveSeconds;
+    private int sessionKeepAliveSeconds;
     private long lastSessionStart=0;
+    private int sessionRefreshThreshold;
+    private int sessionDurationSeconds;
 
     /**
      * Instantiate a session to Kaltura that can be used. The sessions can be reused between Kaltura calls without authenticating again.
@@ -72,28 +79,42 @@ public class DsKalturaClient {
      * @param token The application token used for generating client sessions
      * @param tokenId The id of the application token
      * @param adminSecret The adminsecret used as password for authenticating. Must not be shared.
-     * @param sessionKeepAliveSeconds Reuse the Kaltura Session for performance. Sessions will be refreshed at the given interval. Recommended value 86400 (1 day)
+     * @param sessionDurationSeconds Reuse the Kaltura Session for performance. Sessions will be refreshed at the given interval. Recommended value 86400 (1 day)
      *
      * Either a token/tokenId a adminSecret must be provided for authentication.
      *
      * @throws IOException  If session could not be created at Kaltura
      */
-    public DsKalturaClient(String kalturaUrl, String userId, int partnerId, String token, String tokenId, String adminSecret, long sessionKeepAliveSeconds) throws IOException {
-        if (sessionKeepAliveSeconds <600) { //Enforce some kind of reuse of session since authenticating sessions will accumulate at Kaltura.
-            throw new IllegalArgumentException("SessionKeepAliveSeconds must be at least 600 seconds (10 minutes) ");
-        }               
+    public DsKalturaClient(String kalturaUrl, String userId, int partnerId, String token, String tokenId,
+                           String adminSecret, int sessionDurationSeconds, int sessionRefreshThreshold) throws IOException {
+        this.sessionDurationSeconds=sessionDurationSeconds;
+        this.sessionRefreshThreshold=sessionRefreshThreshold;
+        this.sessionKeepAliveSeconds=sessionDurationSeconds-sessionRefreshThreshold;
         this.kalturaUrl=kalturaUrl;
         this.userId=userId;
         this.token=token;
         this.tokenId=tokenId;
-        this.adminSecret = adminSecret;
+        this.adminSecret=adminSecret;
         this.partnerId=partnerId;
-        this.sessionKeepAliveSeconds=sessionKeepAliveSeconds;
+
+        if (sessionKeepAliveSeconds <600) { //Enforce some kind of reuse of session since authenticating sessions will accumulate at Kaltura.
+            throw new IllegalArgumentException("SessionKeepAliveSeconds must be at least 600 seconds (10 minutes) ");
+        }
+
         getClientInstance();// Start a session already now so it will not fail later when used if credentials fails.
     }
 
+    public DsKalturaClient(String kalturaUrl, String userId, int partnerId, String token, String tokenId,
+                           String adminSecret, int sessionDurationSeconds) throws IOException {
+       this(kalturaUrl, userId, partnerId, token, tokenId,
+                adminSecret, sessionDurationSeconds, 0);
+    }
 
-    /** 
+    public Client getKalturaClient() {
+        return client;
+    }
+
+    /**
      * <p>
      * Delete a stream and all meta-data for the record in Kaltura.
      * It can not be restored in Kaltura and must be uploaded again if deleted by mistake.       
@@ -188,6 +209,7 @@ public class DsKalturaClient {
      * @throws IOException if the remote request failed.
      */
     public Map<String, String> getKalturaIds(List<String> referenceIds) throws IOException, APIException {
+        getClientInstance();
         if (referenceIds.isEmpty()) {
             log.info("getKulturaInternalIds(referenceIDs) called with empty list of IDs");
             return Collections.emptyMap();
@@ -550,7 +572,7 @@ public class DsKalturaClient {
      * Synchronized to avoid race condition if using the DsKalturaClient class multi-threaded
      *
      */
-    private synchronized Client getClientInstance() throws IOException{
+    public synchronized Client getClientInstance() throws IOException{
         try {
             if (this.client == null || System.currentTimeMillis()-lastSessionStart >= sessionKeepAliveSeconds*1000) {
                 log.info("Refreshing Kaltura client session, millis since last refresh:"+(System.currentTimeMillis()-lastSessionStart));
@@ -590,7 +612,8 @@ public class DsKalturaClient {
             ks = startAppTokenSession(client, tokenId, token, SessionType.ADMIN);
         } else {
             log.warn("Starting KalturaSession from adminsecret. Use appToken instead unless you generating appTokens.");
-            ks = client.generateSession(adminSecret, userId, SessionType.ADMIN, this.partnerId);
+            ks = client.generateSession(adminSecret, userId, SessionType.ADMIN, this.partnerId,
+                    sessionDurationSeconds);
         }
 
         client.setKs(ks);
@@ -601,19 +624,57 @@ public class DsKalturaClient {
      * @param client The Kaltura client. Needs to be initialized with config, endpoint and partner ID
      * @return Kaltura Session
      */
-    private String startWidgetSession(Client client) {
+    public String startWidgetSession(Client client, @Nullable Integer expiry ) throws APIException, IOException {
         log.debug("Generating Widget Session...");
+        client.setKs(null);
         String widgetId = "_" + client.getPartnerId();
-        int expiry = Client.EXPIRY;
-        SessionService.StartWidgetSessionSessionBuilder requestBuilder =
-                SessionService.startWidgetSession(widgetId,
-                        expiry);
-        var request = requestBuilder.build(client);
+        SessionService.StartWidgetSessionSessionBuilder requestBuilder;
+        if(expiry == null) {
+            requestBuilder = SessionService.startWidgetSession(widgetId);
+        }else{
+            requestBuilder = SessionService.startWidgetSession(widgetId, expiry);
+        }
+        log.debug(requestBuilder.toString());
         Response<StartWidgetSessionResponse> response =
-                (Response<StartWidgetSessionResponse>) APIOkRequestsExecutor.getExecutor().execute(request);
+                (Response<StartWidgetSessionResponse>) APIOkRequestsExecutor.getExecutor().execute(requestBuilder.build(client, true));
+
+        if(!response.isSuccess()){
+            throw response.error;
+        }
+        log.debug("widget session: {}", response.results.getKs());
         return response.results.getKs();
     }
 
+    public String startWidgetSession(Client client) throws APIException, IOException {
+        return startWidgetSession(client, null);
+    }
+
+    public String getSessionInfo(String ks) throws APIException, IOException {
+
+        SessionService.GetSessionBuilder requestBuilder = SessionService.get(ks);
+
+        Response<SessionInfo> response =
+                (Response<SessionInfo>)APIOkRequestsExecutor.getExecutor().execute(requestBuilder.build(client));
+
+        if(!response.isSuccess()){
+            log.debug(response.error.getMessage());
+            return null;
+        }
+
+        // Convert Unix time to LocalDateTime
+        LocalDateTime localDateTime = Instant.ofEpochSecond(response.results.getExpiry())
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+        log.debug("Session expiry: {}, Privileges: {}, Session type: {}", localDateTime,
+                response.results.getPrivileges(), response.results.getSessionType());
+        // Format the LocalDateTime to a readable format
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        String formattedDateTime = localDateTime.format(formatter);
+
+        return formattedDateTime;
+
+
+    }
 
     /**
      * Computes a SHA-256 hash of token and Kaltura Session
@@ -666,15 +727,14 @@ public class DsKalturaClient {
      * @throws UnsupportedEncodingException
      * @throws NoSuchAlgorithmException
      */
-    private String startAppTokenSession(Client client, String tokenId, String token, SessionType type) throws APIException, UnsupportedEncodingException, NoSuchAlgorithmException {
-
-        String widgetSession = startWidgetSession(client);
+    private String startAppTokenSession(Client client, String tokenId, String token, SessionType type) throws APIException,
+            IOException, NoSuchAlgorithmException {
+        String widgetSession = startWidgetSession(client, sessionDurationSeconds);
         client.setKs(widgetSession);
-        client.setSessionId(widgetSession);
         String hash = computeHash(token, widgetSession);
 
         AppTokenService.StartSessionAppTokenBuilder sessionBuilder =
-                AppTokenService.startSession(tokenId, hash,null,type);
+                AppTokenService.startSession(tokenId, hash,null, type, sessionDurationSeconds);
         Response<SessionInfo> response = (Response<SessionInfo>)
                 APIOkRequestsExecutor.getExecutor().execute(sessionBuilder.build(client));
         if(!response.isSuccess()){
@@ -683,6 +743,4 @@ public class DsKalturaClient {
         }
         return response.results.getKs();
     }
-
-
 }

--- a/src/main/java/dk/kb/kaltura/jobs/JobsBase.java
+++ b/src/main/java/dk/kb/kaltura/jobs/JobsBase.java
@@ -20,9 +20,11 @@ public abstract class JobsBase {
         String token=ServiceConfig.getConfig().getString("kaltura.token");
         String tokenId=ServiceConfig.getConfig().getString("kaltura.tokenId");
         String adminSecret=ServiceConfig.getConfig().getString("kaltura.adminSecret");
-        int keepAliveSeconds=ServiceConfig.getConfig().getInteger("kaltura.sessionKeepAliveSeconds");
+        int sessionDurationSeconds = ServiceConfig.getConfig().getInteger("sessionDurationSeconds");
+        int sessionRefreshThreshold = ServiceConfig.getConfig().getInteger("sessionRefreshThreshold");
 
-        DsKalturaClient client = new DsKalturaClient(kalturaUrl, userId, partnerId, token, tokenId, adminSecret, keepAliveSeconds);
+        DsKalturaClient client = new DsKalturaClient(kalturaUrl, userId, partnerId, token, tokenId, adminSecret,
+                sessionDurationSeconds, sessionRefreshThreshold);
         return client;        
     }
 }

--- a/src/main/java/dk/kb/kaltura/jobs/JobsBase.java
+++ b/src/main/java/dk/kb/kaltura/jobs/JobsBase.java
@@ -20,7 +20,7 @@ public abstract class JobsBase {
         String token=ServiceConfig.getConfig().getString("kaltura.token");
         String tokenId=ServiceConfig.getConfig().getString("kaltura.tokenId");
         String adminSecret=ServiceConfig.getConfig().getString("kaltura.adminSecret");
-        long keepAliveSeconds=ServiceConfig.getConfig().getLong("kaltura.sessionKeepAliveSeconds");
+        int keepAliveSeconds=ServiceConfig.getConfig().getInteger("kaltura.sessionKeepAliveSeconds");
 
         DsKalturaClient client = new DsKalturaClient(kalturaUrl, userId, partnerId, token, tokenId, adminSecret, keepAliveSeconds);
         return client;        

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -5,9 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.kaltura.client.Client;
-import com.kaltura.client.Configuration;
-import com.kaltura.client.services.SessionService;
 import com.kaltura.client.types.APIException;
 import com.kaltura.client.types.AppToken;
 import dk.kb.kaltura.client.AppTokenClient;
@@ -21,7 +18,6 @@ import com.kaltura.client.enums.MediaType;
 
 import dk.kb.kaltura.client.DsKalturaClient;
 
-import static com.kaltura.client.APIOkRequestsExecutor.getExecutor;
 import static org.junit.jupiter.api.Assertions.*;
 
 

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -5,15 +5,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.kaltura.client.Client;
+import com.kaltura.client.Configuration;
+import com.kaltura.client.services.SessionService;
 import com.kaltura.client.types.APIException;
 import com.kaltura.client.types.AppToken;
 import dk.kb.kaltura.client.AppTokenClient;
 import dk.kb.kaltura.config.ServiceConfig;
 import dk.kb.util.yaml.YAML;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +21,7 @@ import com.kaltura.client.enums.MediaType;
 
 import dk.kb.kaltura.client.DsKalturaClient;
 
+import static com.kaltura.client.APIOkRequestsExecutor.getExecutor;
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -33,7 +34,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class KalturaApiIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(KalturaApiIntegrationTest.class);
 
-    private static final long DEFAULT_KEEP_ALIVE = 86400;
+    private static final int DEFAULT_SESSION_DURATION_SECONDS = 86400;
+    private static final int DEFAULT_REFRESH_THRESHOLD = 1800;
 
     // ID's valid as of 2024-04-25 but subject to change
     // TODO: Add a step to setup() creating test kaltura<->reference IDs 
@@ -204,7 +206,7 @@ public class KalturaApiIntegrationTest {
     @Test
     public void deleteAppToken() throws Exception {
         AppTokenClient client = new AppTokenClient(ServiceConfig.getConfig().getString("kaltura.adminSecret"));
-        client.deleteAppToken("0_zjli5ev2");
+        client.deleteAppToken("");
     }
 
     private DsKalturaClient getClient() throws IOException {
@@ -216,7 +218,8 @@ public class KalturaApiIntegrationTest {
                 conf.getString("token"),
                 conf.getString("tokenId"),
                 conf.getString("adminSecret",null),
-                conf.getLong("sessionKeepAliveSeconds", DEFAULT_KEEP_ALIVE));
+                conf.getInteger("sessionDurationSeconds", DEFAULT_SESSION_DURATION_SECONDS),
+                conf.getInteger("sessionRefreshThreshold", DEFAULT_REFRESH_THRESHOLD));
     }
 
 }

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -10,7 +10,10 @@ import com.kaltura.client.types.AppToken;
 import dk.kb.kaltura.client.AppTokenClient;
 import dk.kb.kaltura.config.ServiceConfig;
 import dk.kb.util.yaml.YAML;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +34,7 @@ public class KalturaApiIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(KalturaApiIntegrationTest.class);
 
     private static final int DEFAULT_SESSION_DURATION_SECONDS = 86400;
-    private static final int DEFAULT_REFRESH_THRESHOLD = 1800;
+    private static final int DEFAULT_REFRESH_THRESHOLD = 3600;
 
     // ID's valid as of 2024-04-25 but subject to change
     // TODO: Add a step to setup() creating test kaltura<->reference IDs 

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -74,7 +74,7 @@ public class KalturaApiIntegrationTest {
     @Test
     public void testKalturaSession() throws Exception {
         DsKalturaClient clientSession = getClient();
-        clientSession.getSessionInfo();
+        clientSession.logSessionInfo();
     }
 
     @Test

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -75,6 +75,7 @@ public class KalturaApiIntegrationTest {
     @Test
     public void testKalturaSession() throws Exception {
         DsKalturaClient clientSession = getClient();
+        clientSession.getSessionInfo();
     }
 
     @Test


### PR DESCRIPTION
### Changed
- Config to use sessionDurationSeconds and sessionRefreshThreshold instead of keepAliveSeconds.
  KeepAliveSeconds is now calculated from these two parameters and sessionDurationSeconds is used when starting a
  session.
- Changed KeepAliveSession from long to int.
- Changed startWidgetSession to take a nullable Integer to set specific Expiry. This should not be lower than 600
    due to Kaltura caching of responses.


### Added
- Added getSessionInfo that logs sessionInfo. Only used for testing.