### PR TITLE
DRA-2131-Fix-getKalturaInternalId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that extends DsKalturaClientBase. DsKalturaClientBase maintains kaltura sessions, generically builds and sends API 
   requests to kaltura and unpacks API responses. This serves to reduce the responsibilities and complexity of each 
   method residing in child classes.
+- Changed getKalturaInternalId to detect entries that are rejected.
 
 ### Added
 

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -1,18 +1,19 @@
 package dk.kb.kaltura.client;
 
-import com.kaltura.client.enums.*;
+import com.kaltura.client.enums.ESearchEntryFieldName;
+import com.kaltura.client.enums.ESearchItemType;
+import com.kaltura.client.enums.ESearchOperatorType;
+import com.kaltura.client.enums.MediaType;
 import com.kaltura.client.services.BaseEntryService;
 import com.kaltura.client.services.ESearchService;
 import com.kaltura.client.services.MediaService;
 import com.kaltura.client.services.MediaService.AddContentMediaBuilder;
 import com.kaltura.client.services.MediaService.DeleteMediaBuilder;
-import com.kaltura.client.services.MediaService.ListMediaBuilder;
 import com.kaltura.client.services.MediaService.RejectMediaBuilder;
 import com.kaltura.client.services.UploadTokenService;
 import com.kaltura.client.types.*;
 import com.kaltura.client.utils.request.BaseRequestBuilder;
 import com.kaltura.client.utils.response.base.Response;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -112,9 +112,9 @@ public class DsKalturaClient extends DsKalturaClientBase {
      *
      * @param referenceId External reference ID given when uploading the entry to Kaltura.
      * @return The Kaltura id (internal id). Return null if the refId is not found.
-     * @throws IOException if more than 1 entry was found with the referenceId.
+     * @throws IOException  if more than 1 entry was found with the referenceId.
      * @throws APIException if the client failed to establish an kaltura session or if the request itself was
-     * unsuccessful.
+     *                      unsuccessful.
      */
     public String getKalturaInternalId(String referenceId) throws IOException, APIException {
         List<ESearchEntryBaseItem> items = List.of(createReferenceIdItem(referenceId));
@@ -139,7 +139,7 @@ public class DsKalturaClient extends DsKalturaClientBase {
      * @return a map from {@code referenceID} to {@code kalturaID}.
      * Unresolvable {@code referenceIDs} will not be present in the map.
      * @throws APIException if the client failed to establish an kaltura session or if the request itself was
-     * unsuccessful.
+     *                      unsuccessful.
      */
     public Map<String, String> getKalturaIds(List<String> referenceIds) throws APIException {
         if (referenceIds.isEmpty()) {

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -218,6 +218,16 @@ public class DsKalturaClient extends DsKalturaClientBase {
         return (Response<ESearchEntryResponse>) response;
     }
 
+    /**
+     * Creates a search entry builder for the given list of ESearchEntryBaseItems.
+     *
+     * <p>Validates that the list size does not exceed the current batch size limit.
+     * Configures search parameters with an OR operator and sets up pagination.</p>
+     *
+     * @param items a list of {@link ESearchEntryBaseItem} to search. Must not exceed the batch size limit.
+     * @return an instance of {@link ESearchService.SearchEntryESearchBuilder} configured for the search.
+     * @throws IllegalArgumentException if the size of {@code items} exceeds the batch size limit.
+     */
     private ESearchService.SearchEntryESearchBuilder getSearchEntryESearchBuilder(List<ESearchEntryBaseItem> items) {
         if (items.size() > getBatchSize()) {
             throw new IllegalArgumentException(

--- a/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
+++ b/src/main/java/dk/kb/kaltura/client/DsKalturaClient.java
@@ -112,7 +112,9 @@ public class DsKalturaClient extends DsKalturaClientBase {
      *
      * @param referenceId External reference ID given when uploading the entry to Kaltura.
      * @return The Kaltura id (internal id). Return null if the refId is not found.
-     * @throws IOException if Kaltura called failed, or more than 1 entry was found with the referenceId.
+     * @throws IOException if more than 1 entry was found with the referenceId.
+     * @throws APIException if the client failed to establish an kaltura session or if the request itself was
+     * unsuccessful.
      */
     public String getKalturaInternalId(String referenceId) throws IOException, APIException {
         List<ESearchEntryBaseItem> items = List.of(createReferenceIdItem(referenceId));
@@ -136,7 +138,8 @@ public class DsKalturaClient extends DsKalturaClientBase {
      * @param referenceIds a list of {@code referenceIDs}, typically UUIDs from stream filenames.
      * @return a map from {@code referenceID} to {@code kalturaID}.
      * Unresolvable {@code referenceIDs} will not be present in the map.
-     * @throws IOException if the remote request failed.
+     * @throws APIException if the client failed to establish an kaltura session or if the request itself was
+     * unsuccessful.
      */
     public Map<String, String> getKalturaIds(List<String> referenceIds) throws APIException {
         if (referenceIds.isEmpty()) {

--- a/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
+++ b/src/test/java/dk/kb/kaltura/KalturaApiIntegrationTest.java
@@ -35,10 +35,10 @@ public class KalturaApiIntegrationTest {
     // TODO: Add a step to setup() creating test kaltura<->reference IDs 
     public static final String KALTURA_ID1 = "0_954nx5eh";
     public static final String KALTURA_ID2 = "0_sjjppu7s";
-    public static final String KALTURA_ID3 = "0_zo7k1tgh";
+    public static final String KALTURA_ID3 = "0_zo7k1tgh"; //Rejected
     public static final String REFERENCE_ID1 = "0b1af131-879a-4286-8637-50f0f4b0705f";
     public static final String REFERENCE_ID2 = "9ee1e45a-60e4-4a9d-a44e-72c089bc924d";
-    public static final String REFERENCE_ID3 = "8cd60e55-72a2-482e-9715-67a2f884a285";
+    public static final String REFERENCE_ID3 = "8cd60e55-72a2-482e-9715-67a2f884a285"; //Rejected
 
     // referenceID, kalturaID
     public static final List<List<String>> KNOWN_PAIRS_1 = List.of(
@@ -78,8 +78,29 @@ public class KalturaApiIntegrationTest {
         assertThrows(APIException.class, () -> clientSession.getEntry("NotAEntry"));
     }
 
+
     @Test
-    public void kalturaIDsLookup() throws IOException, APIException {
+    public void kalturaIDLookup() throws IOException, APIException {
+        DsKalturaClient client = getClient();
+        // Known pairs with different moderationStatus
+        for (List<String> knownPair : KNOWN_PAIRS) {
+            String refID = knownPair.get(0);
+            String kalID = knownPair.get(1);
+
+            String res = client.getKalturaInternalId(refID);
+            assertEquals(kalID, res);
+        }
+
+        //No Entry with refID
+        String res = client.getKalturaInternalId("notRefId");
+        assertNull(res);
+
+        //More than one entry with refID
+        assertThrows(IOException.class, () -> client.getKalturaInternalId("ref_test_1234s"));
+    }
+
+    @Test
+    public void kalturaIDsLookup() throws APIException {
         Map<String, String> map = getClient().getKalturaIds(
                 KNOWN_PAIRS.stream().map(e -> e.get(0)).collect(Collectors.toList()));
         log.debug("kalturaIDsLookup() got {} results from {} IDs", map.size(), KNOWN_PAIRS.size());


### PR DESCRIPTION
Changed getKalturaInternalId to detect entries that are rejected. Added test for getKalturaInternalId called kalturaIDLookup().

Also extracted some code from getKalturaIds to method getSearchEntryESearchBuilder(), in order to reuse this in getKalturaInternalId.